### PR TITLE
Update Fisher installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package contains [Nx (Extensible Dev Tools for Monorepos)](https://nx.dev) 
 > This package uses [Jq](https://stedolan.github.io/jq/) so make sure you have it installed. Brew will do on OSX.
 
 ```
-fisher add jukben/fish-nx
+fisher install jukben/fish-nx
 ```
 
 ## Usage


### PR DESCRIPTION
Fisher 4.x has a new way of installing plugins ([source](https://github.com/jorgebucaran/fisher))